### PR TITLE
add support for fpm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,10 @@ RUN yum install -y http://download.fedoraproject.org/pub/epel/6/x86_64/epel-rele
 RUN yum install -y docker-io wget 
 RUN yum install -y bzr patch s3cmd mercurial git sqlite-devel tar bash make ssh gcc
 
+# for fpm
+RUN yum install -y rpm ruby-devel rubygems
+RUN gem install fpm
+
 # download go 1.4.x needed for bootstrapping cloudflare 1.5 to /root/go1.4/
 RUN curl -s https://storage.googleapis.com/golang/go1.4.3.linux-amd64.tar.gz | tar -vxz --xform 's|^go|go1.4|' -C /root
 RUN mkdir -p /usr/local/src && cd /usr/local/src && git clone --branch go1.5.3-cloudflare1 https://github.com/cloudflare/go.git

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
-
-	IMAGE = stackengine/buildbox:1.0.9
+IMAGE=stackengine/buildbox:1.0.12
 
 build:
 	docker build --tag=$(IMAGE) .


### PR DESCRIPTION
DEMO:

```
vagrant@mesh-01:~/src/orahub.oraclecorp.com/opc-cs-dev/buildbox$ make
docker build --tag=stackengine/buildbox:1.0.12 .
...
Step 6 : RUN gem install fpm
 ---> Running in d9c1c37d7413

vagrant@mesh-01:~/src/orahub.oraclecorp.com/opc-cs-dev/buildbox$ docker run -h buildbox-1_0_12 -it --user root -v /home/vagrant/src/orahub.oraclecorp.com/opc-cs-dev/occs:/go/src/orahub.oraclecorp.com/opc-cs-dev/occs stackengine/buildbox:1.0.12 bash
[root@buildbox-1_0_12 controller]# fpm
Missing required -s flag. What package source did you want? {:level=>:warn}

```
