### PR TITLE
fixed build image error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,9 +34,9 @@ RUN go get -u github.com/golang/lint/golint && \
 	go install ./golint
 
 # download and install npm, gulp, karma for the ui nodejs
-RUN curl --silent --location https://rpm.nodesource.com/setup_5.x | bash - &&
-	yum -y install nodejs &&
-	npm install -g gulp &&
+RUN curl --silent --location https://rpm.nodesource.com/setup_5.x | bash - && \
+	yum -y install nodejs && \
+	npm install -g gulp && \
 	npm install -g karma
 
 WORKDIR /go/src/orahub.oraclecorp.com/opc-cs-dev/occs


### PR DESCRIPTION
ISSUE

```
Build failed: The command '/bin/sh -c curl --silent --location https://rpm.nodesource.com/setup_5.x | bash - &&' returned a non-zero code: 1
```
